### PR TITLE
DLS-11085: [VatChecker] Migrate vat-registered-companies-api to HttpClientV2

### DIFF
--- a/app/uk/gov/hmrc/vatregisteredcompaniesapi/connectors/VatRegisteredCompaniesConnector.scala
+++ b/app/uk/gov/hmrc/vatregisteredcompaniesapi/connectors/VatRegisteredCompaniesConnector.scala
@@ -18,15 +18,16 @@ package uk.gov.hmrc.vatregisteredcompaniesapi.connectors
 
 import javax.inject.Inject
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.vatregisteredcompaniesapi.models._
 import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class VatRegisteredCompaniesConnector @Inject()(
-  http: HttpClient,
+  http: HttpClientV2,
   environment: Environment,
   configuration: Configuration,
   servicesConfig: ServicesConfig
@@ -37,9 +38,13 @@ class VatRegisteredCompaniesConnector @Inject()(
   def lookup(lookup: Lookup)
     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[LookupResponse]] = lookup.requester match {
     case Some(requester) =>
-      http.GET[LookupResponse](url = s"$url/lookup/${lookup.target.clean}/$requester").map(Some(_))
+      http.get(url"$url/lookup/${lookup.target.clean}/$requester")
+        .execute[LookupResponse]
+        .map(Some(_))
     case a =>
-      http.GET[LookupResponse](url = s"$url/lookup/${lookup.target.clean}").map(Some(_))
+      http.get(url"$url/lookup/${lookup.target.clean}")
+        .execute[LookupResponse]
+        .map(Some(_))
   }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,7 +25,7 @@ api.context = organisations/vat/check-vat-number
 
 application.logger.name = ${appName}
 
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"


### PR DESCRIPTION
[
![Screenshot from 2024-11-18 15-29-27](https://github.com/user-attachments/assets/bec9fae2-fef5-4747-b30e-ee908bd1983b)
![Screenshot from 2024-11-18 15-29-11](https://github.com/user-attachments/assets/613c1ea7-bde4-4ee1-bdc6-c0b1f54aeb4b)
](url)